### PR TITLE
fix: Datasource caching and settings are fixed in SqlOutboundTransport to fix #6 issue

### DIFF
--- a/common/application.properties
+++ b/common/application.properties
@@ -321,12 +321,18 @@ sql.transport.dataSource.removeAbandonedOnMaintenance=false
 sql.transport.dataSource.removeAbandonedOnBorrow=false
 
 # Specific properties for Oracle JDBC driver. Value -1 can be set to skip the corresponding setting.
+# QA testing showed instable unclear behavior in case sql.transport.dataSource.ojdbc.* properties
+# were set to some positive values. So, all 3 below variables are set = -1.
+# Please test them carefully prior to setting again.
 ## 'oracle.jdbc.ReadTimeout' Manages timeout while reading from the socket. Timeout is in milliseconds.
-sql.transport.dataSource.ojdbc.ReadTimeout=600000
+## 600000 tried, replaced to -1.
+sql.transport.dataSource.ojdbc.ReadTimeout=-1
 ## 'oracle.net.CONNECT_TIMEOUT' Specifies the timeout when connecting a socket to the database listener. Timeout is in seconds. 0 - driver default.
-sql.transport.dataSource.ojdbc.ConnectTimeout=10
+## 10 tried, replaced to -1.
+sql.transport.dataSource.ojdbc.ConnectTimeout=-1
 ## 'oracle.net.OUTBOUND_CONNECT_TIMEOUT' Specifies the timeout when negotiating a session with the database listener. Timeout is in seconds. 0 - driver default.
-sql.transport.dataSource.ojdbc.OutboundConnectTimeout=15
+## 15 tried, replaced to -1.
+sql.transport.dataSource.ojdbc.OutboundConnectTimeout=-1
 
 ## === TCP dump settings ===
 tcpdump.folder=tcpdump

--- a/mockingbird-transports-camel/mockingbird-transport-sql/src/main/java/org/qubership/automation/itf/transport/sql/outbound/SqlOutboundTransport.java
+++ b/mockingbird-transports-camel/mockingbird-transport-sql/src/main/java/org/qubership/automation/itf/transport/sql/outbound/SqlOutboundTransport.java
@@ -171,11 +171,11 @@ public class SqlOutboundTransport extends AbstractOutboundTransportImpl {
                 .getIntOrDefault("sql.transport.dataSource.maxConnLifetimeMillis", 1800000);
 
         ojdbcReadTimeout = Config.getConfig()
-                .getIntOrDefault("sql.transport.dataSource.ojdbc.ReadTimeout", 600000);
+                .getIntOrDefault("sql.transport.dataSource.ojdbc.ReadTimeout", -1);
         ojdbcConnectTimeout = Config.getConfig()
-                .getIntOrDefault("sql.transport.dataSource.ojdbc.ConnectTimeout", 10);
+                .getIntOrDefault("sql.transport.dataSource.ojdbc.ConnectTimeout", -1);
         ojdbcOutboundConnectTimeout = Config.getConfig()
-                .getIntOrDefault("sql.transport.dataSource.ojdbc.OutboundConnectTimeout", 15);
+                .getIntOrDefault("sql.transport.dataSource.ojdbc.OutboundConnectTimeout", -1);
 
         dataSourcesCacheEnable = Boolean.parseBoolean(Config.getConfig()
                 .getStringOrDefault("sql.transport.dataSourcesCache.enable", "true"));


### PR DESCRIPTION
It was investigated, that https://github.com/Netcracker/qubership-testing-platform-itf-executor/issues/6 issue is due to incorrect datasources init and caching in SqlOutboundTransport. Due to it, some threads become infinite waiting for a lock at getting datasources from the cache.
In this PR, 
- datasources properties are added,
- cache manipulations are fully rewritten. 